### PR TITLE
Removing unnecessary extra characters

### DIFF
--- a/docs/Clipboard Redirection.md
+++ b/docs/Clipboard Redirection.md
@@ -64,7 +64,7 @@ To indent,
 To unindent,
 
 ```sh
-|sed "s/^	//"`.
+|sed "s/^	//"
 ```
 
 Notice the quotations in both of these examples! They are required when working with whitespace characters. These examples also use tab characters, which must be pasted into Telepipe's command entry.


### PR DESCRIPTION
I assume the backtick was a left-over from Markdown syntax when the code was inline?